### PR TITLE
Update requirements for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.1",
-        "php" : "~5.6|~7.0"
+        "illuminate/support": "5.*|~6",
+        "php" : "~5.6|~7.*"
     },
     "require-dev": {
-        "phpunit/phpunit" : "~4.0||~5.0||~6.0",
+        "phpunit/phpunit" : "~4.0||~5.0||~6.0||~7.0||~8.0",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {


### PR DESCRIPTION
Illuminate/support 6 is added and since laravel 6 requires php 7.2 this was updated as well.